### PR TITLE
Finishing TODO's for installation setup.

### DIFF
--- a/content/docs/en/getting-started/2-installation.md
+++ b/content/docs/en/getting-started/2-installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-contributors: [rigor789]
+contributors: [rigor789 , TheOriginalJosh]
 ---
 
 In order to use NativeScript-Vue, your system will need to set up properly
@@ -8,18 +8,41 @@ so that your applications can compile.
 
 ## Prerequisites
 
+- [Node.js](#nodejs)
 - [NativeScript-CLI](#nativescript-cli)
-- [Android SDK](#android-sdk) (for developing and testing Android applications)
-- [XCode](#xcode) (mac only - for developing iOS applications)
+- [Windows](#windows) (for developing Android applications on Windows)
+- [macOS](#macos) (for developing iOS and Android applications on macOS)
+- [Linux](#macos) (for developing Android applications on Linux)
+
+### Node.js
+
+Download and install the latest "LTS" version of Node.js from [https://nodejs.org/](https://nodejs.org/). Restart your terminal and verify the installation was successful with the command `node --version`.
 
 ### NativeScript-CLI
 
-// todo: insert description about nativescript-cli
+To install the NativeScript CLI open your terminal and run the command
 
-### Android SDK
+```shell
+npm install -g nativescript
+```
 
-// todo: insert info about android sdk, and a link to a guide for installing it
+You can verify the installation was successful by running `tns` in your terminal. You should see a list of all the available commands.
 
-### XCode
 
-// todo: insert info about xcode, and a link to a guide for installing it
+### Windows
+
+System Requirements and setup instructions for the Android SDK on Windows
+
+[Advanced setup : Windows](https://docs.nativescript.org/start/ns-setup-win)
+
+### macOS
+
+System Requirements and setup instructions to setup XCode and the Android SDK development environments for your Mac.
+
+[Advanced setup: macOS](https://docs.nativescript.org/start/ns-setup-os-x)
+
+### Linux
+
+System Requirements and setup instructions for the Android SDK on Linux
+
+[Advanced setup: Linux](https://docs.nativescript.org/start/ns-setup-linux)


### PR DESCRIPTION
I added the Node.js prerequisite and opened to change the SDK installation instructions from Android and Xcode to the three separate OS instructions with links to the Official Documentation. It makes sense to change these since they are essentially just links to NativeScripts documentation and the setup is different for each major OS.  I hope this is alright.