### PR TITLE
Added 'textWrap' to the 'Label' doc

### DIFF
--- a/content/docs/en/elements/components/label.md
+++ b/content/docs/en/elements/components/label.md
@@ -24,11 +24,11 @@ Example:
 ```html
 <Label textWrap="true">
   <FormattedString>
-    <Span text="This text has a" />
+    <Span text="This text has a " />
     <Span text="red " style="color: red" />
-    <Span text="piece of text." />
-    <Span text=" This bit is italic." fontStyle="italic" />
-    <Span text=" And this bit is bold." fontWeight="bold" />
+    <Span text="piece of text. " />
+    <Span text="Also, this bit is italic, " fontStyle="italic" />
+    <Span text="and this bit is bold." fontWeight="bold" />
   </FormattedString>
 </Label>
 ```

--- a/content/docs/en/elements/components/label.md
+++ b/content/docs/en/elements/components/label.md
@@ -1,7 +1,7 @@
 ---
 title: Label
 apiRef: https://docs.nativescript.org/api-reference/classes/_ui_label_.label
-contributors: [MisterBrownRSA, rigor789]
+contributors: [MisterBrownRSA, rigor789, eddyverbruggen]
 ---
 
 The Label component is used to display read-only text.
@@ -22,11 +22,13 @@ If you need to style certain parts of the text differently, you can use a combin
 
 Example:
 ```html
-<Label>
+<Label textWrap="true">
   <FormattedString>
     <Span text="This text has a" />
-    <Span text="red " style="color: red;" />
+    <Span text="red " style="color: red" />
     <Span text="piece of text." />
+    <Span text=" This bit is italic." fontStyle="italic" />
+    <Span text=" And this bit is bold." fontWeight="bold" />
   </FormattedString>
 </Label>
 ```
@@ -36,6 +38,7 @@ Example:
 | name | type | description |
 |------|------|-------------|
 | `text` | `String` | The text of the label.
+| `textWrap` | `boolean` | Determines whether or not the Label wraps text. Default `false`.
 
 ## Native Component
 


### PR DESCRIPTION
Also, showing how to use **bold** and *italic* text with `FormattedString`.