### PR TITLE
Added more properties to the 'TextField' doc

### DIFF
--- a/content/docs/en/elements/components/text-field.md
+++ b/content/docs/en/elements/components/text-field.md
@@ -1,7 +1,7 @@
 ---
 title: TextField
 apiRef: https://docs.nativescript.org/api-reference/modules/_ui_text_field_
-contributors: [MisterBrownRSA, rigor789, TheOriginalJosh]
+contributors: [MisterBrownRSA, rigor789, TheOriginalJosh, eddyverbruggen]
 
 ---
 
@@ -27,16 +27,21 @@ The TextField component creates an editable single-line box.
 |------|------|-------------|
 | `text` | `String` | The value of the TextField.
 | `hint` | `String` | The placeholder text.
+| `maxLength` | `Number` | Limits input to a certain number of characters.
+| `secure` | `Boolean` | Hides the entered text when `true`. Default `false`.
+| `keyboardType` | `KeyboardType` | Shows a custom keyboard for easier text input. Can be one of `datetime`, `phone`, `number`, `url`, or `email`.
+| `returnKeyType` | `ReturnKeyType` | The label of the return key. Can be one of `done`, `next`, `go`, `search`, or `send`.
 
 ## Events
 
 | name | description |
 |------|-------------|
 | `textChange`| Emitted when the text changes.
+| `returnPress`| Emitted when the return key is pressed.
 | `focus`| Emitted when the textfield is in focus.
-| `blur`| Emitted when the textfield leaves focus.
+| `blur`| Emitted when the textfield loses focus.
 
 ## Native Component
 | Android | iOS |
 |---------|-----|
-| android.widget.Button | UIButton
+| android.widget.EditText | UITextField

--- a/content/docs/en/elements/components/text-field.md
+++ b/content/docs/en/elements/components/text-field.md
@@ -27,6 +27,7 @@ The TextField component creates an editable single-line box.
 |------|------|-------------|
 | `text` | `String` | The value of the TextField.
 | `hint` | `String` | The placeholder text.
+| `editable` | `Boolean` | When `true`, the user can edit the value of the TextField.
 | `maxLength` | `Number` | Limits input to a certain number of characters.
 | `secure` | `Boolean` | Hides the entered text when `true`. Default `false`.
 | `keyboardType` | `KeyboardType` | Shows a custom keyboard for easier text input. Can be one of `datetime`, `phone`, `number`, `url`, or `email`.


### PR DESCRIPTION
I think the `type` should always be lowercase actually (`number`, `string`, etc), but since this is used in all this repo's docs let's stick to capitalization for now (easy refactor if/when we decide this needs to change).