### PR TITLE
The navigation dropdown doesn't work

### DIFF
--- a/layouts/docs.ejs
+++ b/layouts/docs.ejs
@@ -11,7 +11,7 @@
     <%- include('_partials/header') %>
     <div class="bg-grey-lighter md:hidden">
         <div class="container mx-auto p-4">
-            <select v-nav class="w-full p-2" title="Navigation">
+            <select v-model="selected" onchange="window.location = this.options[this.selectedIndex].value" class="w-full p-2" title="Navigation">
                 <%- include('_partials/categories_select', { entry: { children: meta.docs_categories } }) %>
             </select>
         </div>

--- a/layouts/docs.ejs
+++ b/layouts/docs.ejs
@@ -11,7 +11,7 @@
     <%- include('_partials/header') %>
     <div class="bg-grey-lighter md:hidden">
         <div class="container mx-auto p-4">
-            <select v-model="selected" onchange="window.location = this.options[this.selectedIndex].value" class="w-full p-2" title="Navigation">
+            <select onchange="window.location = this.options[this.selectedIndex].value" class="w-full p-2" title="Navigation">
                 <%- include('_partials/categories_select', { entry: { children: meta.docs_categories } }) %>
             </select>
         </div>


### PR DESCRIPTION
When using a small viewport on desktop, or browsing on a mobile phone, a dropdown is shown. This dropdown looks nice... but doesn't work.

I'm not sure what `v-nav` was supposed to do, but a standard browser directive like `onchange="window.location = this.options[this.selectedIndex].value"` gets the job done nicely.