### PR TITLE
Templates > Add vue-cli-template & fix projects links

### DIFF
--- a/content/docs/en/getting-started/3-templates.md
+++ b/content/docs/en/getting-started/3-templates.md
@@ -6,6 +6,27 @@ outdated: true
 
 You can use NativeScript's [template system](https://docs.nativescript.org/tooling/app-templates) to bootstrap your `nativescript-vue` app. All these templates generate a NativeScript app that uses the `nativescript-vue` plugin. Some templates are equipped with more features such as support for Vue.js Single File Components (`.vue`) and livereload.
 
+## vue-cli-template
+
+#### Project link
+
+[https://github.com/nativescript-vue/vue-cli-template](https://github.com/nativescript-vue/vue-cli-template)
+
+#### Description
+
+This template is meant to be installed with [vue-cli (2.x)](https://github.com/vuejs/vue-cli) and is a great starting point for quick prototyping.
+
+#### Installation
+
+First, [install vue-cli 2.x](https://vuejs.org/v2/guide/installation.html#CLI), then run:
+
+```shell
+$ vue init nativescript-vue/vue-cli-template <project-name>
+$ cd <project-name>
+$ npm install # or yarn
+```
+*Follow the [project link](https://github.com/nativescript-vue/vue-cli-template) for further instructions.*
+
 ## nativescript-vue-template
 
 #### Project link

--- a/content/docs/en/getting-started/3-templates.md
+++ b/content/docs/en/getting-started/3-templates.md
@@ -31,7 +31,7 @@ $ npm install # or yarn
 
 #### Project link
 
-[](https://github.com/tralves/nativescript-vue-template)
+[https://github.com/tralves/nativescript-vue-template](https://github.com/tralves/nativescript-vue-template)
 
 #### Description
 
@@ -49,7 +49,7 @@ $ tns create sample-app --template nativescript-vue-template
 
 #### Project link
 
-[](https://github.com/tralves/nativescript-vue-rollup-template)
+[https://github.com/tralves/nativescript-vue-rollup-template](https://github.com/tralves/nativescript-vue-rollup-template)
 
 #### Description
 Originally a [fork from rigor789's](https://github.com/rigor789/nativescript-vue-rollup-template), this template is currently the most stable and feature complete. You can see it in action in the [🍏 🍍 🍓 Groceries Vue](https://github.com/tralves/groceries-ns-vue) app.
@@ -73,7 +73,7 @@ $ tns create sample-app --template nativescript-vue-rollup-template
 
 #### Project link
 
-[](https://github.com/tralves/nativescript-vue-webpack-template)
+[https://github.com/tralves/nativescript-vue-webpack-template](https://github.com/tralves/nativescript-vue-webpack-template)
 
 #### Description
 


### PR DESCRIPTION
Hi!
I recently started using NativeScript-Vue and had a great experience with vue-cli-template which isn't mentioned in the doc, is there a particular reason for that? I think it would be great to give it more visibility.
Also, the "Project link" sections for all template are currently empty due to some missing markdown, this PR fixes this.