### PR TITLE
Needed to prepare plugin for use

### DIFF
--- a/content/docs/en/getting-started/5-nativescript-plugins.md
+++ b/content/docs/en/getting-started/5-nativescript-plugins.md
@@ -13,6 +13,8 @@ Install the plugin using the NativeScript CLI:
 $ npm install --save nativescript-gradient
 ```
 
+**Note:** If you are using the [vue-cli-template](/en/docs/getting-started/templates/#nativescript-vuevue-cli-template) you may have to run the following:
+
 ```shell
 $ npm run clean
 ```

--- a/content/docs/en/getting-started/5-nativescript-plugins.md
+++ b/content/docs/en/getting-started/5-nativescript-plugins.md
@@ -13,6 +13,10 @@ Install the plugin using the NativeScript CLI:
 $ npm install --save nativescript-gradient
 ```
 
+```shell
+$ npm run clean
+```
+
 Open your app entry file and add the following to the top:
 
 ```js


### PR DESCRIPTION
This allows the plugin to be used within NativeScript Vue. 
Otherwise the plugin will not be accessible and will throw errors about missing files etc.