### PR TITLE
Existing documentation was rather confusing, please accept this correction.

### DIFF
--- a/content/docs/en/elements/components/tab-view.md
+++ b/content/docs/en/elements/components/tab-view.md
@@ -47,9 +47,20 @@ contributors: [MisterBrownRSA, rigor789, eddyverbruggen, ikoevska, kharysharpe]
 
 ## Events
 
-| Name | Description |
-|------|-------------|
-| `selectedIndexChanged` | Emitted when one of the `<TabViewItem>` components is tapped.
+| Name | Attr      | Description |
+|------|-----------|-------------|
+| `tabChange` | @tabChange="onTabViewChange" | Emitted when one of the `<TabViewItem>` components is tapped. 
+
+**Note:** Current event is not identical to the ns library, this is a wrapper event for vue specifically.
+
+```js
+methods:{
+   onTabViewChange(index)
+   {
+      console.log('onTabViewChange', index);
+   }
+}
+```
 
 ## Native component
 

--- a/content/docs/en/elements/components/tab-view.md
+++ b/content/docs/en/elements/components/tab-view.md
@@ -47,9 +47,9 @@ contributors: [MisterBrownRSA, rigor789, eddyverbruggen, ikoevska, kharysharpe]
 
 ## Events
 
-| Name | Attr      | Description |
+| Name | example      | Description |
 |------|-----------|-------------|
-| `tabChange` | @tabChange="onTabViewChange" | Emitted when one of the `<TabViewItem>` components is tapped. 
+| `tabChange` | `@tabChange="onTabViewChange"` | Emitted when one of the `<TabViewItem>` components is tapped. 
 
 **Note:** Current event is not identical to the ns library, this is a wrapper event for vue specifically.
 


### PR DESCRIPTION
I think it would be pertinent to update this piece of documentation because I personally got hung up on why the event system was not kicking off on the `<TabView>` component, I believe later this should be updated to use the original event name from ns.