### PR TITLE
Update tab-view.md With correct event name for the tabChange event.

### DIFF
--- a/content/docs/en/elements/components/tab-view.md
+++ b/content/docs/en/elements/components/tab-view.md
@@ -49,7 +49,7 @@ contributors: [MisterBrownRSA, rigor789, eddyverbruggen, ikoevska, kharysharpe]
 
 | Name | Description |
 |------|-------------|
-| `selectedIndexChanged` | Emitted when one of the `<TabViewItem>` components is tapped.
+| `tabChange` | Emitted when one of the `<TabViewItem>` components is tapped.
 
 ## Native component
 


### PR DESCRIPTION
From personal experience, and confirmed in the nativescript vue slack channel. The event name fired on a tab change is 'tabChange' not selectedIndexChanged.

I'm not sure if the intention is to change the actual event name, but at the moment it is very confusing for anybody reading the docs so I thought it'd be better to follow the current spec.