### PR TITLE
Updated phrasing for API box template

### DIFF
--- a/layouts/docs.ejs
+++ b/layouts/docs.ejs
@@ -45,7 +45,7 @@
                                   target="_blank"
                                   rel="noopener"
                                   class="no-underline text-green hover:text-blue-dark">
-                                the full API docs for the <%= current.title %>.
+                                the full API docs for <%= current.title %>.
                             </a>
                         </p>
                     </div>


### PR DESCRIPTION
Current phrasing of the API box sounds like "the full API docs for the Progress" or "the ListView" which sounds either unfinished or not entirely grammatically correct. We can either drop the extra "the" or go with "the X component" (which might not work in all cases).