### PR TITLE
Change Manual to Frame routing

### DIFF
--- a/content/docs/en/routing/manual-routing.md
+++ b/content/docs/en/routing/manual-routing.md
@@ -1,6 +1,6 @@
 ---
-title: Manual Routing
-contributors: [eddyverbruggen, fartek, rigor789]
+title: Frame Routing
+contributors: [eddyverbruggen, fartek, rigor789, misterbrownza]
 ---
 
 The easiest way to do routing in NativeScript-Vue is using the convenience functions


### PR DESCRIPTION
Manual might be disingenuous for users who have no idea about the underlying technology, but I think the article should let the user know that they are working with the nativescript internal routing...