### PR TITLE
Fixed event name for TabView in translations

### DIFF
--- a/content/docs/ko/elements/components/tab-view.md
+++ b/content/docs/ko/elements/components/tab-view.md
@@ -31,7 +31,7 @@ contributors: [qgp9]
 
 | 이름 | 설명 |
 |------|-------------|
-| `selectedIndexChanged`| tab-view-item 컴포넌트중 하나가 탭되었을때 발생
+| `tabChange`| tab-view-item 컴포넌트중 하나가 탭되었을때 발생
 
 ## Native Component
 | Android | iOS |

--- a/content/docs/pt-BR/elements/components/tab-view.md
+++ b/content/docs/pt-BR/elements/components/tab-view.md
@@ -35,7 +35,7 @@ contributors: [alexhiroshi]
 
 | nome | descrição |
 |------|-------------|
-| `selectedIndexChanged` | Emitido quando um componente `<TabViewItem>` é tocado.
+| `tabChange` | Emitido quando um componente `<TabViewItem>` é tocado.
 
 ## Componente Nativo
 


### PR DESCRIPTION
Solves: https://github.com/nativescript-vue/nativescript-vue.org/issues/69