### PR TITLE
Add forum link to community dropdown

### DIFF
--- a/layouts/_partials/header.ejs
+++ b/layouts/_partials/header.ejs
@@ -77,6 +77,10 @@
                            target="_blank"
                            rel="noopener"
                            class="no-underline text-blue-lightest md:text-blue-dark hover:bg-green hover:text-white px-4 py-2">Slack</a>
+                        <a href="https://discourse.nativescript.org/c/vue"
+                           target="_blank"
+                           rel="noopener"
+                           class="no-underline text-blue-lightest md:text-blue-dark hover:bg-green hover:text-white px-4 py-2">Slack</a>
                     </div>
                 </div>
             </div>

--- a/layouts/_partials/header.ejs
+++ b/layouts/_partials/header.ejs
@@ -80,7 +80,7 @@
                         <a href="https://discourse.nativescript.org/c/vue"
                            target="_blank"
                            rel="noopener"
-                           class="no-underline text-blue-lightest md:text-blue-dark hover:bg-green hover:text-white px-4 py-2">Slack</a>
+                           class="no-underline text-blue-lightest md:text-blue-dark hover:bg-green hover:text-white px-4 py-2">Forum</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Thought it might be good to add the forum link to the list.
When looking for previously answered questions, forum posts are easier to search through than slack.