### PR TITLE
Correcting 'timeChange' Event in TimePicker component

### DIFF
--- a/content/docs/en/elements/components/time-picker.md
+++ b/content/docs/en/elements/components/time-picker.md
@@ -39,7 +39,7 @@ See also: [DatePicker](/en/docs/elements/components/date-picker).
 
 | Name | Description |
 |------|-------------|
-| `timeChanged` | Emitted when the selected time changes.
+| `timeChange` | Emitted when the selected time changes.
 
 ## Native component
 


### PR DESCRIPTION
The event is 'timeChange' but the docs currently say 'timeChanged'. Correcting this to avoid confusion for any new users.