### PR TITLE
Fix event name

### DIFF
--- a/content/docs/en/elements/components/tab-view.md
+++ b/content/docs/en/elements/components/tab-view.md
@@ -51,7 +51,7 @@ contributors: [MisterBrownRSA, rigor789, eddyverbruggen, ikoevska, kharysharpe]
 
 | Name | Description |
 |------|-------------|
-| `tabChange` | Emitted when one of the `<TabViewItem>` components is tapped.
+| `selectedIndexChange` | Emitted when one of the `<TabViewItem>` components is tapped.
 
 ## Native component
 

--- a/content/docs/es/elements/components/tab-view.md
+++ b/content/docs/es/elements/components/tab-view.md
@@ -50,7 +50,7 @@ contributors: [ianaya89]
 
 | Nombre | Descripción |
 |------|-------------|
-| `tabChange` | Emitido cada vez que un componente `<TabViewItem>` es presionado.
+| `selectedIndexChange` | Emitido cada vez que un componente `<TabViewItem>` es presionado.
 
 ## Componente Nativo
 

--- a/content/docs/pt-BR/elements/components/tab-view.md
+++ b/content/docs/pt-BR/elements/components/tab-view.md
@@ -35,7 +35,7 @@ contributors: [alexhiroshi]
 
 | nome | descrição |
 |------|-------------|
-| `tabChange` | Emitido quando um componente `<TabViewItem>` é tocado.
+| `selectedIndexChange` | Emitido quando um componente `<TabViewItem>` é tocado.
 
 ## Componente Nativo
 

--- a/content/docs/ru/elements/components/tab-view.md
+++ b/content/docs/ru/elements/components/tab-view.md
@@ -50,7 +50,7 @@ contributors: [MisterBrownRSA, rigor789, eddyverbruggen, ikoevska, kharysharpe]
 
 | Имя | Описание |
 |------|-------------|
-| `tabChange` | Срабатывает при нажатии на один из компонентов `<TabViewItem>`.
+| `selectedIndexChange` | Срабатывает при нажатии на один из компонентов `<TabViewItem>`.
 
 ## Нативный компонент
 


### PR DESCRIPTION
As per https://github.com/nativescript-vue/nativescript-vue/blob/a4e2fa57af8e1e2fc56698216a8271a232b86ff2/platform/nativescript/runtime/components/tab-view.js the event name is different than the one that is shown in the docs. 