### PR TITLE
Fix minor typo 'ativescript' -> 'nativescript'

### DIFF
--- a/content/docs/cn/elements/action-bar/action-bar.md
+++ b/content/docs/cn/elements/action-bar/action-bar.md
@@ -20,7 +20,7 @@ ActionBar组件是Android ActionBar和iOS NavigationBar的NativeScript抽象。
 <ActionBar>
   <StackLayout orientation="horizontal">
     <Image src="res://icon" width="40" height="40" verticalAlignment="center" />
-    <Label text="ativeScript" fontSize="24" verticalAlignment="center" />
+    <Label text="NativeScript" fontSize="24" verticalAlignment="center" />
   </StackLayout>
 </ActionBar>
 ```

--- a/content/docs/en/elements/action-bar/action-bar.md
+++ b/content/docs/en/elements/action-bar/action-bar.md
@@ -20,7 +20,7 @@ The ActionBar component is a NativeScript abstraction for the Android ActionBar 
 <ActionBar>
   <StackLayout orientation="horizontal">
     <Image src="res://icon" width="40" height="40" verticalAlignment="center" />
-    <Label text="ativeScript" fontSize="24" verticalAlignment="center" />
+    <Label text="NativeScript" fontSize="24" verticalAlignment="center" />
   </StackLayout>
 </ActionBar>
 ```

--- a/content/docs/es/elements/action-bar/action-bar.md
+++ b/content/docs/es/elements/action-bar/action-bar.md
@@ -21,7 +21,7 @@ El componente ActionBar es una abstraccio4n de NativeScript del `ActionBar` de A
 <ActionBar>
   <StackLayout orientation="horizontal">
     <Image src="res://icon" width="40" height="40" verticalAlignment="center" />
-    <Label text="ativeScript" fontSize="24" verticalAlignment="center" />
+    <Label text="NativeScript" fontSize="24" verticalAlignment="center" />
   </StackLayout>
 </ActionBar>
 ```

--- a/content/docs/ko/elements/action-bar/action-bar.md
+++ b/content/docs/ko/elements/action-bar/action-bar.md
@@ -20,7 +20,7 @@ contributors: [rigor789, eddyverbruggen]
 <ActionBar>
   <StackLayout orientation="horizontal">
     <Image src="res://icon" width="40" height="40" verticalAlignment="center" />
-    <Label text="ativeScript" fontSize="24" verticalAlignment="center" />
+    <Label text="NativeScript" fontSize="24" verticalAlignment="center" />
   </StackLayout>
 </ActionBar>
 ```

--- a/content/docs/pt-BR/elements/action-bar/action-bar.md
+++ b/content/docs/pt-BR/elements/action-bar/action-bar.md
@@ -20,7 +20,7 @@ O componente ActionBar é uma abstração do NativeScript para o ActionBar do An
 <ActionBar>
   <StackLayout orientation="horizontal">
     <Image src="res://icon" width="40" height="40" verticalAlignment="center" />
-    <Label text="ativeScript" fontSize="24" verticalAlignment="center" />
+    <Label text="NativeScript" fontSize="24" verticalAlignment="center" />
   </StackLayout>
 </ActionBar>
 ```

--- a/content/docs/ru/elements/action-bar/action-bar.md
+++ b/content/docs/ru/elements/action-bar/action-bar.md
@@ -20,7 +20,7 @@ contributors: [sn0wil]
 <ActionBar>
   <StackLayout orientation="horizontal">
     <Image src="res://icon" width="40" height="40" verticalAlignment="center" />
-    <Label text="ativeScript" fontSize="24" verticalAlignment="center" />
+    <Label text="NativeScript" fontSize="24" verticalAlignment="center" />
   </StackLayout>
 </ActionBar>
 ```


### PR DESCRIPTION
I was reading through the docs and noticed a super minor typo. 