### PR TITLE
Fix minor typo: change HTML `<Label>` to `<label>`

### DIFF
--- a/content/docs/en/elements/components/label.md
+++ b/content/docs/en/elements/components/label.md
@@ -6,7 +6,7 @@ contributors: [MisterBrownRSA, rigor789, eddyverbruggen, ikoevska]
 
 `<Label>` is a UI component that displays read-only text.
 
-**IMPORTANT**: This `<Label>` is **not** the same as the HTML `<Label>`.
+**IMPORTANT**: This `<Label>` is **not** the same as the HTML `<label>`.
 
 ---
 


### PR DESCRIPTION
HTML tag names are technically case-insensitive, but conventionally they are lowercase, so `<label>` looks more familiar when referring to the HTML element.