### PR TITLE
Explicitly specify path in Event description

### DIFF
--- a/content/docs/en/elements/components/list-picker.md
+++ b/content/docs/en/elements/components/list-picker.md
@@ -32,7 +32,7 @@ contributors: [MisterBrownRSA, rigor789, ikoevska]
 
 | Name | Description |
 |------|-------------|
-| `selectedIndexChange`| Emitted when the currently selected option (index) changes. The new index can be retrieve on `$event.value`.
+| `selectedIndexChange`| Emitted when the currently selected option (index) changes. The new index can be retrieved via `$event.value`.
 
 ## Native component
 

--- a/content/docs/en/elements/components/list-picker.md
+++ b/content/docs/en/elements/components/list-picker.md
@@ -32,7 +32,7 @@ contributors: [MisterBrownRSA, rigor789, ikoevska]
 
 | Name | Description |
 |------|-------------|
-| `selectedIndexChange`| Emitted when the currently selected option (index) changes.
+| `selectedIndexChange`| Emitted when the currently selected option (index) changes. The new index can be retrieve on `$event.value`.
 
 ## Native component
 


### PR DESCRIPTION
Explicitly describe the path of the new index: `$event.value`.