### PR TITLE
docs(en): remove the mentions of the `bundle` and `hmr` flags

### DIFF
--- a/content/docs/en/getting-started/1-quick-start.md
+++ b/content/docs/en/getting-started/1-quick-start.md
@@ -23,12 +23,9 @@ $ npm install
 $ # or
 $ yarn install
 $
-$ tns run android --bundle
+$ tns preview
 $ # or
-$ tns run ios --bundle
-$
-$ # You may also try the new HMR mode by replacing --bundle
-$ # with --hmr, but note that this is a beta feature.
+$ tns run
 ```
 
 This set of commands performs the following operations on your system:
@@ -37,4 +34,5 @@ This set of commands performs the following operations on your system:
 2. Creates a project using the [vue-cli-template](https://github.com/nativescript-vue/vue-cli-template).
 3. Switches to the directory containing the newly created project.
 4. Installs any npm dependencies locally.
-5. Builds and runs the project on any connected devices or installed emulators for the selected platform. The `--bundle` option triggers a webpack build, which compiles `.vue` files and watches for changes.
+5. If executing `tns preview`, produces a QR code which can be used to preview the app on a device.
+6. If executing `tns run`, builds and runs the project on all connected devices or in native emulators.

--- a/content/docs/en/getting-started/4-upgrade-guide.md
+++ b/content/docs/en/getting-started/4-upgrade-guide.md
@@ -31,9 +31,9 @@ $ npm install -g @vue/cli @vue/cli-init
 $ vue init nativescript-vue/vue-cli-template <project-name>
 $ cd <project-name>
 $ npm install
-$ tns run android --bundle
+$ tns preview
 $ # or
-$ tns run ios --bundle
+$ tns run
 ```
 
 ## Step 2: Replace `App_Resources`
@@ -181,12 +181,10 @@ Run the following command to clean the new app's folders and reinstall any depen
 $ cd <project-name>
 $ rm -rf platforms
 $ npm install
-$ tns run android --bundle
-$ # or
-$ tns run ios --bundle
+$ tns run
 ```
 
-## (Optional) Step 8: Try HMR
+## (Optional) Step 9: Try HMR
 
 NativeScript now provides support for HMR (Hot Module Replacement). The latest version of NativeScript-Vue provides out-of-the-box HMR support as well but requires the NativeScript CLI. 
 
@@ -196,7 +194,5 @@ Run the following command to get HMR support by installing the latest and greate
 $ npm install -g nativescript@next
 $ cd <project-name>
 $ rm -rf platforms
-$ tns run android --hmr
-$ # or
-$ tns run ios --hmr
+$ tns run
 ```

--- a/content/docs/en/getting-started/5-vue-devtools.md
+++ b/content/docs/en/getting-started/5-vue-devtools.md
@@ -65,9 +65,9 @@ Run the following command:
 
 ```shell
 $ rm -rf platforms
-$ tns run android --bundle
+$ tns run android
 $ # or
-$ tns run ios --bundle
+$ tns run ios
 ```
 
 If your machine and app are configured properly, you should see a few components in the component tree of Vue DevTools.


### PR DESCRIPTION
Starting with NativeScript 6.0, the `bundle` and `hmr` flags are now
enabled by default.

This PR should be merged after
https://github.com/nativescript-vue/vue-cli-template/pull/134.