### PR TITLE
Update 1-quick-start.md

### DIFF
--- a/content/docs/pt-BR/getting-started/1-quick-start.md
+++ b/content/docs/pt-BR/getting-started/1-quick-start.md
@@ -16,9 +16,16 @@ $ npm install
 
 e então execute o seu aplicativo usando:
 
-```shell
-$ npm run watch:<platform>
+```shell 
+$ tns run <platform>
 ```
+
+ou se preferir utilizar o aplicativo Nativescript Playground
+
+```shell 
+$ tns preview
+```
+
 
 onde platform é `ios` ou `android`.
 


### PR DESCRIPTION
Fixing the last command to run Nativescript quick start guide. 
**npm run watch** doens't work for me. I had to use **tns run** or **tns preview**