### PR TITLE
Better explanation of ActionBar and $navigateBack behavior.

### DIFF
--- a/content/docs/en/routing/manual-routing.md
+++ b/content/docs/en/routing/manual-routing.md
@@ -12,7 +12,7 @@ The easiest way to implement routing in NativeScript-Vue is to use any of the fo
 > All examples on this page discuss how to handle routing between the `Master` and `Detail` components of a mobile app.
 
 ### Configuring the `ActionBar`
-Remember to set another element (probably a `Layout`) to display the content when setting up an `ActionBar`. Supressing the `Layout` **will not** render a blank page and will result in error. 
+Remember to set another element (probably a `Layout`) to display the content when setting up an `ActionBar`. Suppressing the `Layout` **will not** render a blank page and will result in error. 
 ```Vue
 <Page>
   <ActionBar title="Master" />
@@ -155,7 +155,7 @@ const Detail = {
   `
 };
 ```
-The `$navigateBack` access the children's scope even when called using an `ActionBar` from its parent (when supressing the `ActionBar` on the child component). 
+The `$navigateBack` access the children's scope even when called using an `ActionBar` from its parent (when suppressing the `ActionBar` on the child component). 
 
 ### `$showModal`
 

--- a/content/docs/en/routing/manual-routing.md
+++ b/content/docs/en/routing/manual-routing.md
@@ -11,6 +11,16 @@ The easiest way to implement routing in NativeScript-Vue is to use any of the fo
 
 > All examples on this page discuss how to handle routing between the `Master` and `Detail` components of a mobile app.
 
+### Configuring the `ActionBar`
+Remember to set another element (probably a `Layout`) to display the content when setting up an `ActionBar`. Supressing the `Layout` **will not** render a blank page and will result in error. 
+```Vue
+<Page>
+  <ActionBar title="Master" />
+  <StackLayout /> <!-- Displaying a blank page! -->
+</Page>
+```
+If you don't provive the `ActionBar`, it will use the parents `ActionBar`. 
+
 ### `$navigateTo(Component, options)`
 
 You can call `$navigateTo` in the view or in a method.
@@ -18,6 +28,8 @@ You can call `$navigateTo` in the view or in a method.
 #### In the view
 
 In the `Master` component, use a `data` property to expose the `Detail` component. Invoke `$navigateTo(<propertyName>)` in the view directly.
+
+
 
 ```Vue
 const Vue = require('nativescript-vue');
@@ -143,6 +155,7 @@ const Detail = {
   `
 };
 ```
+The `$navigateBack` access the children's scope even when called using an `ActionBar` from its parent (when supressing the `ActionBar` on the child component). 
 
 ### `$showModal`
 


### PR DESCRIPTION
Better explanation of the following topics:

- Suppressing the `ActionBar` in child components and using parents `$navigateBack`.
- Mandatory `Layout` attribute inside `Page` to use `$navigateTo()`.

Hope it helps.