### PR TITLE
Add bundle flag to the tns preview command

### DIFF
--- a/content/docs/en/getting-started/1-quick-start.md
+++ b/content/docs/en/getting-started/1-quick-start.md
@@ -25,7 +25,7 @@ $ npm install
 $ # or
 $ yarn install
 $
-$ tns preview
+$ tns preview --bundle
 $ # or
 $ tns run
 ```

--- a/content/docs/en/getting-started/1-quick-start.md
+++ b/content/docs/en/getting-started/1-quick-start.md
@@ -36,5 +36,5 @@ This set of commands performs the following operations on your system:
 2. Creates a project using the [vue-cli-template](https://github.com/nativescript-vue/vue-cli-template).
 3. Switches to the directory containing the newly created project.
 4. Installs any npm dependencies locally.
-5. If executing `tns preview`, produces a QR code which can be used to preview the app on a device.
+5. If executing `tns preview`, produces a QR code which can be used to preview the app on a device. The `--bundle` flag is responsible for running webpack which compiles the .vue files.
 6. If executing `tns run`, builds and runs the project on all connected devices or in native emulators.


### PR DESCRIPTION
I had an issue with not knowing why nativescript-vue is not working with the Preview app on the iOS and it was because I went through the quick start and it didn't specify to use the --bundle flag that is responsible for running webpack, which compiles the .vue files.

When searching the web I found that other people also had this issue.