### PR TITLE
feat(routing): include Tabs and Drawer navigation

### DIFF
--- a/content/docs/en/routing/manual-routing.md
+++ b/content/docs/en/routing/manual-routing.md
@@ -1,15 +1,18 @@
 ---
 title: Manual Routing
-contributors: [eddyverbruggen, fartek, rigor789, ikoevska, tralves]
+contributors: [eddyverbruggen, fartek, rigor789, ikoevska, tralves, sis0k0]
 ---
 
 The easiest way to implement routing in NativeScript-Vue is to use any of the following convenience functions:
 
-* [`$navigateTo`](#navigateto)
-* [`$navigateBack`](#navigateback)
-* [`$showModal`](#showmodal)
+* [`$navigateTo`](#navigatetocomponent-options)
+* [`$navigateBack`](#navigatebackoptions-backstackentry--null)
 
-> All examples on this page discuss how to handle routing between the `Master` and `Detail` components of a mobile app.
+For more complex navigation scenarios, you can use multiple `<Frame>` components and a navigation-specific component:
+
+* [`Modal View`](#modal-view-navigation)
+* [`BottomNavigation & Tabs`](#bottomnavigation-and-tabs-navigation)
+* [`SideDrawer`](#sidedrawer-navigation)
 
 ### `$navigateTo(Component, options)`
 
@@ -20,7 +23,7 @@ You can call `$navigateTo` in the view or in a method.
 In the `Master` component, use a `data` property to expose the `Detail` component. Invoke `$navigateTo(<propertyName>)` in the view directly.
 
 ```Vue
-const Vue = require('nativescript-vue');
+import Vue from 'nativescript-vue';
 
 const Master = {
   template: `
@@ -144,7 +147,7 @@ const Detail = {
 };
 ```
 
-### `$showModal`
+### Modal View Navigation
 
 Use `$showModal` to show the `Detail` page modally. This function behaves similarly to `$navigateTo`.
 
@@ -155,7 +158,7 @@ You can call `$showModal` in the view or in a method. To close the modal, call `
 In the `Master` component, use a `data` property to expose the `Detail` component. Invoke `$showModal(<propertyName>)` in the view directly.
 
 ```Vue
-const Vue = require('nativescript-vue');
+import Vue from 'nativescript-vue';
 
 const Master = {
   template: `
@@ -279,4 +282,82 @@ this.$showModal(Detail).then(data => console.log(data));
 ```HTML
 <!-- inside Detail -->
 <Button @tap="$modal.close('Foo')" text="Close" />
+```
+
+### BottomNavigation and Tabs Navigation
+
+The `<BottomNavigation>` and `<Tabs>` components enable the user to arbitrarily navigate between several UI containers at the same level. A key feature of these components is that they keep the state of the containers that are not visible. This means that when the user comes back to a previous tab, the data, scroll position and navigation state should be like they left them. 
+
+The examples below use the `<BottomNavigation>` component. You can use the same markup for the `<Tabs>` component. Just replace the `<BottomNavigation>` tags with `<Tabs>` tags.
+
+The `<BottomNavigation>` container provides its lateral navigation logic automatically by providing the user with tabs which they can select. To set up a `<BottomNavigation>` you need to simply declare the UI of each container (within a `<TabContentItem>`) and the title and icon you want to be shown in its representing tab (within a `<TabStripItem>`). Each separate UI container is represented by a `<TabContentItem>`. A `<TabContentItem>` can have one root component. As with other containers, you can enable forward and backward navigation inside each `<TabContentItem>` by embedding a `<Frame>` in it.
+
+```Vue
+import Vue from 'nativescript-vue';
+
+import Items from './components/Items.vue';
+import Browse from './components/Browse.vue';
+import Search from './components/Search.vue';
+
+const App = {
+  components: {
+    Items,
+    Browse,
+    Search
+  },
+
+  template: `
+    <BottomNavigation>
+      <TabStrip>
+        <TabStripItem>
+          <Label text="Home"></Label>
+        </TabStripItem>
+        <TabStripItem>
+          <Label text="Browse"></Label>
+        </TabStripItem>
+        <TabStripItem>
+          <Label text="Search"></Label>
+        </TabStripItem>
+      </TabStrip>
+
+      <TabContentItem>
+        <Frame>
+          <Items />
+        </Frame>
+      </TabContentItem>
+
+      <TabContentItem>
+        <Frame>
+          <Browse />
+        </Frame>
+      </TabContentItem>
+
+      <TabContentItem>
+        <Frame>
+          <Search />
+        </Frame>
+      </TabContentItem>
+    </BottomNavigation>
+  `
+};
+
+new Vue({
+  render: h => h(App)
+}).$start();
+```
+
+To create a new application utilizing the `<ButtomNavigation>` component run:
+
+```bash
+tns create my-app-name --template tns-template-tab-navigation-vue
+```
+
+### SideDrawer Navigation
+
+The `<RadSideDrawer>` component enables the user to open a hidden view, i.e. drawer, containing navigation controls, or settings from the sides of the screen. For more information about it, read the [dedicated article](https://docs.nativescript.org/vuejs/ns-ui/SideDrawer/getting-started).
+
+To create a new application utilizing the `<RadSideDrawer>` component run:
+
+```bash
+tns create my-app-name --template tns-template-drawer-navigation-vue
 ```


### PR DESCRIPTION
Changes in the `manual-routing` article:

- fix in-article links to `navigateTo` and `navigateBack` sections;
- add a short section about configuring `BottomNavigation` component;
- add a reference to the `RadSideDrawer` docs.