### PR TITLE
Remove redundant Page when using a component

### DIFF
--- a/content/docs/en/elements/components/frame.md
+++ b/content/docs/en/elements/components/frame.md
@@ -46,9 +46,7 @@ If you need to create multiple frames, you can do so by wrapping them in a Layou
 
 ```html
 <Frame>
-  <Page>
-    <Home />
-  </Page>
+  <Home />
 </Frame>
 ```
 


### PR DESCRIPTION
Strange things happen when using a component within a `<Frame>` if a `<Page>` is also declared.

Only Home needs a `<Page>`.