### PR TITLE
Move `supported features` section out of the installing instructions as it breaks the script

### DIFF
--- a/content/docs/en/getting-started/1-quick-start.md
+++ b/content/docs/en/getting-started/1-quick-start.md
@@ -7,15 +7,6 @@ If you don't want the hassle of installing and configuring your system before yo
 
 But if [you already have your system ready for native development](/en/docs/getting-started/installation), you can start by using the [vue-cli-template](https://github.com/nativescript-vue/vue-cli-template):
 
-**Supported features**
-
--   `.vue` single file components
--   Vuex&mdash;state management (opt-in)
--   NativeScript themes
--   Application presets
-
-> **Note**: If you choose to install DevTools, you won't be able to use `tns preview`, as the Preview app doesn't support one of the plugins DevTools uses.
-
 ```shell
 $ npm install -g @vue/cli @vue/cli-init
 $ vue init nativescript-vue/vue-cli-template <project-name>
@@ -38,3 +29,12 @@ This set of commands performs the following operations on your system:
 4. Installs any npm dependencies locally.
 5. If executing `tns preview`, produces a QR code which can be used to preview the app on a device.
 6. If executing `tns run`, builds and runs the project on all connected devices or in native emulators.
+
+**Supported features**
+
+-   `.vue` single file components
+-   Vuex&mdash;state management (opt-in)
+-   NativeScript themes
+-   Application presets
+
+> **Note**: If you choose to install DevTools, you won't be able to use `tns preview`, as the Preview app doesn't support one of the plugins DevTools uses.


### PR DESCRIPTION
The `Supported features` was misplaced in the middle of the installation instructions.

Please note that the phrase above the section was finishing in a `:` as it expected the shell instructions to come next.