### PR TITLE
Update 4-upgrade-guide.md

### DIFF
--- a/content/docs/en/getting-started/4-upgrade-guide.md
+++ b/content/docs/en/getting-started/4-upgrade-guide.md
@@ -28,7 +28,7 @@ Run the following command to create a new project from the Vue-CLI template.
 
 ```shell
 $ npm install -g @vue/cli @vue/cli-init
-$ vue init nativescript-vue/vue-cli-template <project-name>
+$ ns create <project-name> --template @nativescript/template-blank-vue 
 $ cd <project-name>
 $ npm install
 $ tns preview

--- a/content/docs/en/getting-started/4-upgrade-guide.md
+++ b/content/docs/en/getting-started/4-upgrade-guide.md
@@ -28,7 +28,7 @@ Run the following command to create a new project from the Vue-CLI template.
 
 ```shell
 $ npm install -g @vue/cli @vue/cli-init
-$ ns create <project-name> --template @nativescript/template-blank-vue 
+$ ns create <project-name> --vue
 $ cd <project-name>
 $ npm install
 $ tns preview


### PR DESCRIPTION
`vue init nativescript-vue/vue-cli-template <project-name>` command installs the old (v1) template. Instead, use the `@nativescript/template-blank-vue` template