### PR TITLE
Fix event name of SegmentedBar

### DIFF
--- a/content/docs/cn/elements/components/segmented-bar.md
+++ b/content/docs/cn/elements/components/segmented-bar.md
@@ -22,7 +22,7 @@ contributors: [nuochong]
 
 ```html
 <SegmentedBar :items="listOfItems" selectedIndex="0"
-    @selectedIndexChange="onSelectedIndexChange" />
+    @selectedIndexChanged="onSelectedIndexChange" />
 ```
 
 `<SegmentedBar>` 使用提供双向数据绑定 `v-model`。
@@ -45,7 +45,7 @@ contributors: [nuochong]
 
 | 名称 | 描述 |
 |------|-------------|
-| `selectedIndexChange`| 点击分段栏上的项目时发出。
+| `selectedIndexChanged`| 点击分段栏上的项目时发出。
 
 ## 原生组件
 

--- a/content/docs/en/elements/components/segmented-bar.md
+++ b/content/docs/en/elements/components/segmented-bar.md
@@ -22,7 +22,7 @@ As opposed to `<TabView>`:
 
 ```html
 <SegmentedBar :items="listOfItems" selectedIndex="0"
-    @selectedIndexChange="onSelectedIndexChange" />
+    @selectedIndexChanged="onSelectedIndexChange" />
 ```
 
 `<SegmentedBar>` provides two-way data binding using `v-model`.
@@ -45,7 +45,7 @@ As opposed to `<TabView>`:
 
 | Name | Description |
 |------|-------------|
-| `selectedIndexChange`| Emitted when the an item on the segmented bar is tapped.
+| `selectedIndexChanged`| Emitted when the an item on the segmented bar is tapped.
 
 ## Native component
 

--- a/content/docs/es/elements/components/segmented-bar.md
+++ b/content/docs/es/elements/components/segmented-bar.md
@@ -22,7 +22,7 @@ Al contrario de lo que sucede con el componente `<TabView>`:
 
 ```html
 <SegmentedBar :items="listOfItems" selectedIndex="0"
-    @selectedIndexChange="onSelectedIndexChange" />
+    @selectedIndexChanged="onSelectedIndexChange" />
 ```
 
 `<SegmentedBar>` provee enlace de datos bidireccional (*two-way data binding*) usando `v-model`.
@@ -45,7 +45,7 @@ Al contrario de lo que sucede con el componente `<TabView>`:
 
 | Nombre | Descripción |
 |------|-------------|
-| `selectedIndexChange`| Emitido cada vez que un item es presionado.
+| `selectedIndexChanged`| Emitido cada vez que un item es presionado.
 
 ## Componente nativo
 

--- a/content/docs/ja/elements/components/segmented-bar.md
+++ b/content/docs/ja/elements/components/segmented-bar.md
@@ -22,7 +22,7 @@ contributors: [Spice-Z]
 
 ```html
 <SegmentedBar :items="listOfItems" selectedIndex="0"
-    @selectedIndexChange="onSelectedIndexChange" />
+    @selectedIndexChanged="onSelectedIndexChange" />
 ```
 
 `<SegmentedBar>`は`v-model`による双方向バインディングを提供します。
@@ -45,7 +45,7 @@ contributors: [Spice-Z]
 
 | 名前 | 説明 |
 |------|-------------|
-| `selectedIndexChange`| セグメントバーの要素がタップされたときに発火します。
+| `selectedIndexChanged`| セグメントバーの要素がタップされたときに発火します。
 
 ## Native component
 

--- a/content/docs/ko/elements/components/segmented-bar.md
+++ b/content/docs/ko/elements/components/segmented-bar.md
@@ -10,7 +10,7 @@ contributors: [qgp9]
 
 ```html
 <SegmentedBar :items="listOfItems" selectedIndex="0"
-    @selectedIndexChange="onSelectedIndexChange" />
+    @selectedIndexChanged="onSelectedIndexChange" />
 ```
 
 **노트**: 이 컴포넌트는 `v-model` 을 이용한 양방향(two-way) 바인딩을 지원합니다:
@@ -33,7 +33,7 @@ contributors: [qgp9]
 
 | 이름 | 설명 |
 |------|-------------|
-| `selectedIndexChange`| 세그멘트 바의 아이템이 탭될때 발생.
+| `selectedIndexChanged`| 세그멘트 바의 아이템이 탭될때 발생.
 
 ## Native Component
 | Android | iOS |

--- a/content/docs/pt-BR/elements/components/segmented-bar.md
+++ b/content/docs/pt-BR/elements/components/segmented-bar.md
@@ -10,7 +10,7 @@ O componente SegementedBar oferece uma maneira simples de mostrar uma coleção 
 
 ```html
 <SegmentedBar :items="listOfItems" selectedIndex="0"
-    @selectedIndexChange="onSelectedIndexChange" />
+    @selectedIndexChanged="onSelectedIndexChange" />
 ```
 
 **Nota**: Esse componente suporta two-way data binding usando `v-model`:
@@ -33,7 +33,7 @@ O componente SegementedBar oferece uma maneira simples de mostrar uma coleção 
 
 | nome | descrição |
 |------|-------------|
-| `selectedIndexChange`| Emitido quando um item da barra segmentada é tocado
+| `selectedIndexChanged`| Emitido quando um item da barra segmentada é tocado
 
 ## Componente Nativo
 | Android | iOS |

--- a/content/docs/ru/elements/components/segmented-bar.md
+++ b/content/docs/ru/elements/components/segmented-bar.md
@@ -22,7 +22,7 @@ contributors: [sn0wil]
 
 ```html
 <SegmentedBar :items="listOfItems" selectedIndex="0"
-    @selectedIndexChange="onSelectedIndexChange" />
+    @selectedIndexChanged="onSelectedIndexChange" />
 ```
 
 `<SegmentedBar>` обеспечивает двустороннюю привязку данных, используя `v-model`.
@@ -45,7 +45,7 @@ contributors: [sn0wil]
 
 | Имя | Описание |
 |------|-------------|
-| `selectedIndexChange`| Срабатывает при нажатии на элемент в области.
+| `selectedIndexChanged`| Срабатывает при нажатии на элемент в области.
 
 ## Нативный компонент
 


### PR DESCRIPTION
I hit the issue that is described in https://github.com/NativeScript/nativescript-angular/issues/1066#issuecomment-870141928

The values for `newIndex` and `oldIndex` are both `undefined`, if the event name `selectedIndexChange` is used. If the name `selectedIndexChanged` is used instead, the values are set correctly.